### PR TITLE
Refactor dashboard/search logic; add Explore meta and Clear Recent

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,9 +191,10 @@
                         <div class="flex items-center justify-between mb-3">
                           <h2 class="text-xl font-semibold">Explore</h2>
                           <div class="flex items-center space-x-2">
-                            <button id="view-toggle" class="px-3 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded">Grid</button>
+                            <button id="view-toggle" class="px-3 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded">Grid View</button>
                           </div>
                         </div>
+                        <div id="explore-meta" class="mb-3 text-xs sm:text-sm text-gray-600 dark:text-gray-300"></div>
                         <div id="category-chips" class="flex flex-wrap gap-2"></div>
                       </div>
 
@@ -207,6 +208,7 @@
                       <div id="recent-section" class="hidden bg-white dark:bg-gray-800 rounded-xl shadow p-4">
                         <div class="flex items-center justify-between mb-3">
                           <h3 class="text-lg font-semibold">Recent</h3>
+                          <button id="clear-recent" class="text-sm px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600">Clear</button>
                         </div>
                         <div id="recent-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
                       </div>

--- a/index.js
+++ b/index.js
@@ -26,15 +26,30 @@ window.onload = function () {
 document.addEventListener("DOMContentLoaded", () => {
   // --- 1. APP DATA (loaded from apps.json) ---
   let applicationFiles = [];
+  const STORAGE_KEYS = {
+    userHistory: "userHistory",
+    loggedInUser: "loggedInUser",
+    pinnedApps: "pinnedApps",
+    viewMode: "viewMode",
+    sidebarCollapsed: "sidebarCollapsed",
+    theme: "theme",
+  };
+
+  const getAppId = (app) => app.id || app.name;
+  const filterAppsBySearch = (searchTerm = "") => {
+    const query = searchTerm.toLowerCase().trim();
+    if (!query) return applicationFiles;
+    return applicationFiles.filter((app) => app._searchText.includes(query));
+  };
 
   async function loadRegistry() {
     try {
       const res = await fetch('apps.json', { cache: 'no-cache' });
       if (!res.ok) throw new Error('Failed to load apps.json');
-      applicationFiles = await res.json();
+      prepareApplications(await res.json());
     } catch (e) {
       // Fallback registry when running from file:// or offline
-      applicationFiles = [
+      prepareApplications([
         { id: "fake-news-detection", name: "Fake News Detection", file: "Apps/Fake News Detection System.html", icon: "🔍", category: "Content Tools", keywords: "verify truth article analysis" },
         { id: "pdf-extractor", name: "PDF Extractor", file: "Apps/PDF Extraction.html", icon: "📄", category: "Productivity", keywords: "document read text data" },
         { id: "math-problem-solver", name: "Math Problem Solver", file: "Apps/Math_Problem_Solver.html", icon: "🧮", category: "Utilities", keywords: "calculate algebra calculus equation" },
@@ -51,8 +66,16 @@ document.addEventListener("DOMContentLoaded", () => {
         { id: "ai-data-analysis", name: "AI Data Analysis", file: "Apps/AI_Data_Analysis.html", icon: "📈", category: "Productivity", keywords: "data analysis charts graphs ai" },
         { id: "mermaid-diagram-editor", name: "Mermaid Diagram Editor", file: "Apps/Mermaid_Diagram_Editor.html", icon: "🧩", category: "Productivity", keywords: "mermaid diagram flowchart editor" },
         { id: "ratio-calculator", name: "Ratio Calculator", file: "Apps/Ratio_Calc.html", icon: "🧮", category: "Calc", keywords: "Ratio Calculator" }
-      ];
+      ]);
     }
+  }
+
+
+  function prepareApplications(apps) {
+    applicationFiles = apps.map((app) => ({
+      ...app,
+      _searchText: `${app.name || ""} ${app.category || ""} ${app.keywords || ""}`.toLowerCase(),
+    }));
   }
 
   // --- 2. ELEMENT REFERENCES ---
@@ -82,6 +105,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const allGrid = document.getElementById('all-grid');
   const viewToggle = document.getElementById('view-toggle');
   const categoryChips = document.getElementById('category-chips');
+  const exploreMeta = document.getElementById('explore-meta');
+  const clearRecentButton = document.getElementById('clear-recent');
   // Command palette
   const cpModal = document.getElementById('command-palette-modal');
   const cpInput = document.getElementById('command-palette-input');
@@ -102,7 +127,8 @@ document.addEventListener("DOMContentLoaded", () => {
   // --- 3. STATE VARIABLES ---
   let currentUser = null;
   let filterCategory = null;
-  let viewMode = (localStorage.getItem('viewMode') || 'grid');
+  let activeSearchTerm = "";
+  let viewMode = (localStorage.getItem(STORAGE_KEYS.viewMode) || 'grid');
   let ctxAppId = null;
 
   // --- 4. FUNCTIONS ---
@@ -120,7 +146,7 @@ document.addEventListener("DOMContentLoaded", () => {
   function logUserActivity(action, details) {
     if (!currentUser) return;
     const userId = currentUser.id;
-    let history = JSON.parse(localStorage.getItem("userHistory")) || {};
+    let history = JSON.parse(localStorage.getItem(STORAGE_KEYS.userHistory)) || {};
     if (!history[userId]) {
       history[userId] = [];
     }
@@ -130,7 +156,7 @@ document.addEventListener("DOMContentLoaded", () => {
       timestamp: new Date().toISOString(),
     });
     if (history[userId].length > 50) history[userId].pop();
-    localStorage.setItem("userHistory", JSON.stringify(history));
+    localStorage.setItem(STORAGE_KEYS.userHistory, JSON.stringify(history));
   }
 
   // Handles successful Google login
@@ -142,7 +168,7 @@ document.addEventListener("DOMContentLoaded", () => {
       email: credential.email,
       avatar: credential.picture,
     };
-    localStorage.setItem("loggedInUser", JSON.stringify(currentUser));
+    localStorage.setItem(STORAGE_KEYS.loggedInUser, JSON.stringify(currentUser));
     updateUIAfterLogin();
     logUserActivity("Logged In", {
       browser: navigator.userAgent,
@@ -161,7 +187,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Checks for a logged-in user on page load
   function checkSession() {
-    const storedUser = localStorage.getItem("loggedInUser");
+    const storedUser = localStorage.getItem(STORAGE_KEYS.loggedInUser);
     if (storedUser) {
       currentUser = JSON.parse(storedUser);
       updateUIAfterLogin();
@@ -178,8 +204,8 @@ document.addEventListener("DOMContentLoaded", () => {
         appIframe.src = app.file;
         showAppViewer(app.name);
         const p = new URLSearchParams(location.search);
-        p.set('app', app.id || app.name);
-        history.pushState({ app: app.id || app.name }, '', `?${p.toString()}`);
+        p.set('app', getAppId(app));
+        history.pushState({ app: getAppId(app) }, '', `?${p.toString()}`);
         logUserActivity("Viewed App", { appName: app.name });
       })
       .catch(() => {
@@ -217,9 +243,8 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   // Pinned apps management
-  const PINNED_KEY = 'pinnedApps';
-  function getPinned() { return JSON.parse(localStorage.getItem(PINNED_KEY) || '[]'); }
-  function setPinned(ids) { localStorage.setItem(PINNED_KEY, JSON.stringify(ids)); }
+    function getPinned() { return JSON.parse(localStorage.getItem(STORAGE_KEYS.pinnedApps) || '[]'); }
+  function setPinned(ids) { localStorage.setItem(STORAGE_KEYS.pinnedApps, JSON.stringify(ids)); }
   function isPinned(id) { return getPinned().includes(id); }
   function togglePin(id) {
     const pins = new Set(getPinned());
@@ -260,17 +285,17 @@ document.addEventListener("DOMContentLoaded", () => {
   // Recent apps for current user
   function getRecent(limit = 6) {
     if (!currentUser) return [];
-    const hist = JSON.parse(localStorage.getItem('userHistory') || '{}');
+    const hist = JSON.parse(localStorage.getItem(STORAGE_KEYS.userHistory) || '{}');
     const items = hist[currentUser.id] || [];
-    const names = [];
+    const names = new Set();
     const out = [];
     for (const h of items) {
       if (h.action !== 'Viewed App' || !h.details?.appName) continue;
       const app = applicationFiles.find(a => a.name === h.details.appName);
       if (!app) continue;
-      const id = app.id || app.name;
-      if (names.includes(id)) continue;
-      names.push(id);
+      const id = getAppId(app);
+      if (names.has(id)) continue;
+      names.add(id);
       out.push(app);
       if (out.length >= limit) break;
     }
@@ -281,7 +306,7 @@ document.addEventListener("DOMContentLoaded", () => {
   function appCard(app) {
     const card = document.createElement('div');
     card.className = 'app-card cursor-pointer p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:shadow transition flex items-start space-x-3';
-    card.setAttribute('data-app-id', app.id || app.name);
+    card.setAttribute('data-app-id', getAppId(app));
     card.innerHTML = `
       <div class="text-2xl">${app.icon || '📦'}</div>
       <div class="flex-1">
@@ -289,7 +314,7 @@ document.addEventListener("DOMContentLoaded", () => {
         <div class="text-sm text-gray-500 dark:text-gray-400">${app.description || ''}</div>
         <div class="mt-1 text-xs text-gray-400">${app.category || ''}</div>
       </div>
-      <div class="ml-2"><button class="pin-btn text-xs px-2 py-1 rounded bg-gray-100 dark:bg-gray-700">${isPinned(app.id || app.name) ? 'Unpin' : 'Pin'}</button></div>
+      <div class="ml-2"><button class="pin-btn text-xs px-2 py-1 rounded bg-gray-100 dark:bg-gray-700">${isPinned(getAppId(app)) ? 'Unpin' : 'Pin'}</button></div>
     `;
     card.addEventListener('click', (e) => {
       // Avoid clicks on pin button
@@ -298,7 +323,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
     card.querySelector('.pin-btn').addEventListener('click', (e) => {
       e.stopPropagation();
-      togglePin(app.id || app.name);
+      togglePin(getAppId(app));
       renderAll();
     });
     // Context menu on card
@@ -335,32 +360,48 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
+  function renderEmptyState(grid, message) {
+    if (!grid) return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'col-span-full text-sm text-gray-500 dark:text-gray-400 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-4 text-center';
+    wrapper.textContent = message;
+    grid.appendChild(wrapper);
+  }
+
   function renderDashboardGrids() {
     // Pinned
     const pins = getPinned();
-    const pinnedApps = applicationFiles.filter(a => pins.includes(a.id || a.name)).filter(a => !filterCategory || (a.category===filterCategory));
+    const searchableApps = filterAppsBySearch(activeSearchTerm);
+    const pinnedApps = searchableApps.filter(a => pins.includes(getAppId(a))).filter(a => !filterCategory || (a.category===filterCategory));
     if (pinnedApps.length) {
       pinnedSection.classList.remove('hidden');
       pinnedGrid.innerHTML = '';
       pinnedApps.forEach(app => pinnedGrid.appendChild(appCard(app)));
     } else {
       pinnedSection.classList.add('hidden');
+      pinnedGrid.innerHTML = '';
+      renderEmptyState(pinnedGrid, 'No pinned apps yet. Use Pin on any app card.');
     }
 
     // Recent
-    const recents = getRecent().filter(a => !filterCategory || (a.category===filterCategory));
+    const recents = getRecent().filter((a) => searchableApps.some((sApp) => getAppId(sApp) === getAppId(a))).filter(a => !filterCategory || (a.category===filterCategory));
     if (recents.length) {
       recentSection.classList.remove('hidden');
       recentGrid.innerHTML = '';
       recents.forEach(app => recentGrid.appendChild(appCard(app)));
+      if (clearRecentButton) clearRecentButton.classList.remove('hidden');
     } else {
       recentSection.classList.add('hidden');
+      recentGrid.innerHTML = '';
+      renderEmptyState(recentGrid, currentUser ? 'No recently opened apps yet.' : 'Sign in to see your recent apps.');
+      if (clearRecentButton) clearRecentButton.classList.add('hidden');
     }
 
     // All
-    const all = applicationFiles.filter(a => !filterCategory || (a.category===filterCategory));
+    const all = searchableApps.filter(a => !filterCategory || (a.category===filterCategory));
     allGrid.innerHTML = '';
     all.forEach(app => allGrid.appendChild(appCard(app)));
+    if (!all.length) renderEmptyState(allGrid, 'No apps match this category/filter.');
 
     // View mode styling
     const asList = (viewMode === 'list');
@@ -372,18 +413,20 @@ document.addEventListener("DOMContentLoaded", () => {
         grid.className = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4';
       }
     });
-    if (viewToggle) viewToggle.textContent = asList ? 'List' : 'Grid';
+    if (viewToggle) viewToggle.textContent = asList ? 'List View' : 'Grid View';
+    if (exploreMeta) {
+      const visible = all.length;
+      const total = applicationFiles.length;
+      const scope = filterCategory ? ` in ${filterCategory}` : '';
+      exploreMeta.textContent = `Showing ${visible} of ${total} apps${scope}.`;
+    }
   }
 
   function renderSidebar(searchTerm = "") {
     nav.innerHTML = "";
     const lowerCaseSearchTerm = searchTerm.toLowerCase().trim();
 
-    const filteredApps = applicationFiles.filter((app) => {
-      if (!lowerCaseSearchTerm) return true;
-      const searchableText = `${app.name} ${app.category} ${app.keywords}`.toLowerCase();
-      return searchableText.includes(lowerCaseSearchTerm);
-    });
+    const filteredApps = filterAppsBySearch(lowerCaseSearchTerm);
 
     // Split pinned and others
     const pins = new Set(getPinned());
@@ -399,8 +442,8 @@ document.addEventListener("DOMContentLoaded", () => {
       pinnedList.forEach((app) => {
         const link = document.createElement('a');
         link.className = "nav-link flex items-center px-4 py-2 text-gray-600 dark:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white transition-colors overflow-hidden";
-        link.href = `?app=${encodeURIComponent(app.id || app.name)}`;
-        link.setAttribute('data-app-id', app.id || app.name);
+        link.href = `?app=${encodeURIComponent(getAppId(app))}`;
+        link.setAttribute('data-app-id', getAppId(app));
         link.innerHTML = `
                             <span class="nav-link-icon mr-3 flex-shrink-0">${app.icon}</span>
                             <span class="sidebar-text whitespace-nowrap transition-opacity duration-200">${app.name}</span>`;
@@ -424,7 +467,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const sortedCategories = Object.keys(groupedApps).sort();
 
     if (sortedCategories.length === 0 && lowerCaseSearchTerm) {
-      nav.innerHTML = `<p class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">No apps found.</p>`;
+      nav.innerHTML = `<p class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">No apps found for this search.</p>`;
       return;
     }
 
@@ -439,8 +482,8 @@ document.addEventListener("DOMContentLoaded", () => {
         const link = document.createElement("a");
         link.className =
           "nav-link flex items-center px-4 py-2 text-gray-600 dark:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white transition-colors overflow-hidden";
-        link.href = `?app=${encodeURIComponent(app.id || app.name)}`;
-        link.setAttribute('data-app-id', app.id || app.name);
+        link.href = `?app=${encodeURIComponent(getAppId(app))}`;
+        link.setAttribute('data-app-id', getAppId(app));
         link.innerHTML = `
                             <span class="nav-link-icon mr-3 flex-shrink-0">${app.icon}</span>
                             <span class="sidebar-text whitespace-nowrap transition-opacity duration-200">${app.name}</span>`;
@@ -475,7 +518,21 @@ document.addEventListener("DOMContentLoaded", () => {
   // --- 5. EVENT LISTENERS ---
 
   // Search input listener
-  appSearchInput.addEventListener("input", () => renderSidebar(appSearchInput.value));
+  appSearchInput.addEventListener("input", () => {
+    activeSearchTerm = appSearchInput.value || "";
+    renderAll();
+  });
+
+  if (clearRecentButton) {
+    clearRecentButton.addEventListener('click', () => {
+      if (!currentUser) return;
+      const hist = JSON.parse(localStorage.getItem(STORAGE_KEYS.userHistory) || '{}');
+      const userEntries = (hist[currentUser.id] || []).filter((entry) => entry.action !== 'Viewed App');
+      hist[currentUser.id] = userEntries;
+      localStorage.setItem(STORAGE_KEYS.userHistory, JSON.stringify(hist));
+      renderDashboardGrids();
+    });
+  }
 
   // Command palette open/close
   function openCommandPalette() {
@@ -507,7 +564,7 @@ document.addEventListener("DOMContentLoaded", () => {
     e.preventDefault();
     logUserActivity("Logged Out");
     currentUser = null;
-    localStorage.removeItem("loggedInUser");
+    localStorage.removeItem(STORAGE_KEYS.loggedInUser);
     google.accounts.id.disableAutoSelect();
     googleSignInButton.style.display = "block";
     userMenu.classList.add("hidden");
@@ -531,7 +588,7 @@ document.addEventListener("DOMContentLoaded", () => {
   sidebarToggleButton.addEventListener("click", () => {
     document.documentElement.classList.toggle("sidebar-collapsed");
     localStorage.setItem(
-      "sidebarCollapsed",
+      STORAGE_KEYS.sidebarCollapsed,
       document.documentElement.classList.contains("sidebar-collapsed")
     );
   });
@@ -561,14 +618,11 @@ document.addEventListener("DOMContentLoaded", () => {
   function renderCommandPaletteResults(q) {
     cpResults.innerHTML = '';
     const query = (q || '').toLowerCase().trim();
-    let items = applicationFiles;
-    if (query) {
-      items = applicationFiles.filter(a => (`${a.name} ${a.category} ${a.keywords || ''}`).toLowerCase().includes(query));
-    }
+    const items = filterAppsBySearch(query);
     items.slice(0, 50).forEach((app, i) => {
       const li = document.createElement('li');
       li.className = 'px-3 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center justify-between';
-      li.setAttribute('data-app-id', app.id || app.name);
+      li.setAttribute('data-app-id', getAppId(app));
       li.tabIndex = 0;
       li.innerHTML = `<span><span class="mr-2">${app.icon}</span>${app.name}</span><span class="text-xs text-gray-500">${app.category || ''}</span>`;
       li.addEventListener('click', () => { closeCommandPalette(); loadApp(app); });
@@ -598,7 +652,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Context menu logic
   function showContextMenu(x, y, app) {
-    ctxAppId = app.id || app.name;
+    ctxAppId = getAppId(app);
     ctxOpenNew.onclick = () => { window.open(app.file, '_blank', 'noopener'); hideContextMenu(); };
     ctxTogglePin.textContent = isPinned(ctxAppId) ? 'Unpin' : 'Pin';
     ctxTogglePin.onclick = () => { togglePin(ctxAppId); hideContextMenu(); renderAll(); };
@@ -622,7 +676,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // About link - open as modal or new tab (here: modal inside main app)
 const aboutLink = document.getElementById("about-link");
 
-aboutLink.addEventListener("click", (e) => {
+if (aboutLink) aboutLink.addEventListener("click", (e) => {
   e.preventDefault();
   // Show About page in modal
   showAboutModal();
@@ -745,7 +799,7 @@ function showAboutModal() {
   window.addEventListener('beforeinstallprompt', (e) => {
     e.preventDefault();
     deferredInstallPrompt = e;
-    installButton.classList.remove('hidden');
+    if (installButton) installButton.classList.remove('hidden');
   });
   if (installButton) {
     installButton.addEventListener('click', async () => {
@@ -765,14 +819,15 @@ function showAboutModal() {
   }
 
   function renderAll() {
-    renderSidebar(appSearchInput.value || '');
+    activeSearchTerm = appSearchInput.value || '';
+    renderSidebar(activeSearchTerm);
     renderCategoryChips();
     renderDashboardGrids();
   }
 
   if (viewToggle) viewToggle.addEventListener('click', () => {
     viewMode = (viewMode === 'grid') ? 'list' : 'grid';
-    localStorage.setItem('viewMode', viewMode);
+    localStorage.setItem(STORAGE_KEYS.viewMode, viewMode);
     renderDashboardGrids();
   });
 


### PR DESCRIPTION
### Motivation
- Improve dashboard UX by exposing more metadata, clearer view labels, and a way to clear recent items. 
- Make app registry/searching faster and more robust by precomputing search text and centralizing helper utilities. 
- Reduce brittle DOM/storage usage by grouping storage keys and adding safer element guards. 

### Description
- Updated `index.html` to change the view toggle label to `Grid View`, add an `#explore-meta` area for counts, and add a `Clear` button to the Recent section. 
- Large refactor of `index.js`: introduced `STORAGE_KEYS`, `getAppId`, `filterAppsBySearch`, and `prepareApplications`, and precompute `_searchText` on load for faster searches. 
- Centralized and hardened localStorage access (using `STORAGE_KEYS`), added `activeSearchTerm` state, and improved pinned/recent/all rendering with `renderEmptyState` placeholders. 
- Added `clearRecent` handler, made event handlers and element references null-safe (`if (installButton)`, `if (aboutLink)`), and adjusted view toggle text to `Grid View`/`List View`. 

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a438456d2c832c933b40422a1dbb40)