### PR TITLE
chore: Remove obsolete JSZip FIX comment

### DIFF
--- a/Apps/AI_PPT_Maker.html
+++ b/Apps/AI_PPT_Maker.html
@@ -6,7 +6,6 @@
     <title>AI Presentation Maker</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
-    <!-- FIX: Add the JSZip dependency required by pptxgenjs -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.min.js"></script>
     <style>


### PR DESCRIPTION
Removed an obsolete `<!-- FIX: Add the JSZip dependency required by pptxgenjs -->` comment in `Apps/AI_PPT_Maker.html`. The actual JSZip dependency is already present, making the comment unnecessary.

---
*PR created automatically by Jules for task [10885898555666002358](https://jules.google.com/task/10885898555666002358) started by @BTKcreations*