### PR TITLE
🧪 Add tests for loadFromStorage error paths

### DIFF
--- a/tests/storage.test.mjs
+++ b/tests/storage.test.mjs
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { loadFromStorage } from '../src/modules/storage.js';
+
+test('loadFromStorage', async (t) => {
+  const originalError = console.error;
+
+  t.afterEach(() => {
+    global.localStorage = undefined;
+    console.error = originalError;
+  });
+
+  await t.test('returns parsed JSON for existing key', () => {
+    global.localStorage = {
+      getItem: (key) => {
+        if (key === 'multiapp_test_key') {
+          return JSON.stringify({ a: 1 });
+        }
+        return null;
+      }
+    };
+
+    const result = loadFromStorage('test_key');
+    assert.deepStrictEqual(result, { a: 1 });
+  });
+
+  await t.test('returns default value for missing key', () => {
+    global.localStorage = {
+      getItem: () => null
+    };
+
+    const result = loadFromStorage('missing_key', 'default_val');
+    assert.strictEqual(result, 'default_val');
+  });
+
+  await t.test('returns default value if JSON.parse throws (invalid JSON)', () => {
+    global.localStorage = {
+      getItem: () => '{ invalid json'
+    };
+
+    let loggedError = null;
+    console.error = (msg, err) => {
+      loggedError = err;
+    };
+
+    const result = loadFromStorage('test_key', 'default_val');
+    assert.strictEqual(result, 'default_val');
+    assert.ok(loggedError instanceof SyntaxError);
+  });
+
+  await t.test('returns default value if localStorage.getItem throws', () => {
+    global.localStorage = {
+      getItem: () => {
+        throw new Error('Access denied');
+      }
+    };
+
+    let loggedError = null;
+    console.error = (msg, err) => {
+      loggedError = err;
+    };
+
+    const result = loadFromStorage('test_key', 'default_val');
+    assert.strictEqual(result, 'default_val');
+    assert.strictEqual(loggedError.message, 'Access denied');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap in `src/modules/storage.js` was addressed where error handling logic inside `loadFromStorage` was unverified.

📊 **Coverage:** The following scenarios are now tested:
- Happy path (valid JSON)
- Missing key path (returns default value)
- Parse error path (invalid JSON correctly caught, returns default value)
- Exception path (localStorage.getItem throws, caught, returns default value)

✨ **Result:** Improved test coverage and guaranteed robustness of `loadFromStorage` utilizing `node:test` framework.

---
*PR created automatically by Jules for task [14145812318377160708](https://jules.google.com/task/14145812318377160708) started by @BTKcreations*